### PR TITLE
Add cocoapod support for ios

### DIFF
--- a/react-native-acpcore.podspec
+++ b/react-native-acpcore.podspec
@@ -16,6 +16,12 @@ Pod::Spec.new do |s|
   s.frameworks = "UIKit", "SystemConfiguration", "WebKit",
                  "UserNotifications"
 
+  s.vendored_libraries = "ios/libs/libACPCore_iOS.a",
+                         "ios/libs/libACPIdentity_iOS.a",
+                         "ios/libs/libACPLifecycle_iOS.a",
+                         "ios/libs/libACPSignal_iOS.a"
+
+
   s.library = "c++", "z", "sqlite3.0"
 
   s.requires_arc = true

--- a/react-native-acpcore.podspec
+++ b/react-native-acpcore.podspec
@@ -1,0 +1,28 @@
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = "react-native-acpcore"
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.homepage     = "https://github.com/adobe/react-native-acpcore"
+  s.license      = "MIT"
+  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
+  s.author             = "Adobe"
+  s.platform     = :ios, "9.0"
+  s.source       = { :git => "https://github.com/adobe/react-native-acpcore", :tag => "v1.0.2" }
+
+# Platform dependencies
+  s.frameworks = "UIKit", "SystemConfiguration", "WebKit",
+                 "UserNotifications"
+
+  s.library = "c++", "z", "sqlite3.0"
+
+  s.requires_arc = true
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency "React"
+
+end
+
+  


### PR DESCRIPTION

## Description

Add podspec for cocoapod support

Known issue:
By default, `react-native link` should add pod to Podfile automatically but I am not able to achieve this

## Related Issue

#2 

## Motivation and Context

For easier integration for iOS

## How Has This Been Tested?

Create a react native app with cocoapod initialized 

Add `  pod 'react-native-acpcore', :path => '../node_modules/@adobe/react-native-acpcore'` to Podfile of the ios project

Do a `pod install`

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
