### PR TITLE
Add ACPIdentity.getUrlVariables API

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,12 @@ ACPCore.setAdvertisingIdentifier("adID");
 ACPIdentity.appendVisitorInfoForURL("test.com").then(urlWithVisitorData => console.log("AdobeExperienceSDK: VisitorData = " + urlWithVisitorData));
 ```
 
+##### Get visitor data as URL query parameter string:
+
+```javascript
+ACPIdentity.getUrlVariables().then(urlVariables => console.log("AdobeExperienceSDK: UrlVariables = " + urlVariables));
+```
+
 ##### Get Identifiers:
 
 ```javascript

--- a/__tests__/ACPIdentityTests.js
+++ b/__tests__/ACPIdentityTests.js
@@ -61,6 +61,12 @@ describe('ACPIdentity', () => {
     expect(spy).toHaveBeenCalledWith(url);
   });
 
+  test('getUrlVariables is called', async () => {
+    const spy = jest.spyOn(NativeModules.ACPIdentity, 'getUrlVariables');
+    await ACPIdentity.getUrlVariables();
+    expect(spy).toHaveBeenCalled();
+  });
+
   test('getIdentifiers is called', async () => {
     const spy = jest.spyOn(NativeModules.ACPIdentity, 'getIdentifiers');
     await ACPIdentity.getIdentifiers();

--- a/android/src/main/java/com/adobe/marketing/mobile/reactnative/RCTACPIdentityModule.java
+++ b/android/src/main/java/com/adobe/marketing/mobile/reactnative/RCTACPIdentityModule.java
@@ -87,6 +87,16 @@ public class RCTACPIdentityModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void getUrlVariables(final Promise promise) {
+        Identity.getUrlVariables(new AdobeCallback<String>() {
+            @Override
+            public void call(String s) {
+                promise.resolve(s);
+            }
+        });
+    }
+
+    @ReactMethod
     public void getIdentifiers(final Promise promise) {
         Identity.getIdentifiers(new AdobeCallback<List<VisitorID>>() {
             @Override

--- a/ios/src/Identity/RCTACPIdentity.m
+++ b/ios/src/Identity/RCTACPIdentity.m
@@ -37,6 +37,12 @@ RCT_EXPORT_METHOD(appendVisitorInfoForURL:(nonnull NSString*)baseUrl resolver:(R
     }];
 }
 
+RCT_EXPORT_METHOD(getUrlVariables:((RCTPromiseResolveBlock) resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    [ACPIdentity getUrlVariables:^(NSURL * _Nullable urlVariables) {
+        resolve(urlVariables.absoluteString);
+    }];
+}
+
 RCT_EXPORT_METHOD(getIdentifiers:(RCTPromiseResolveBlock) resolve rejecter:(RCTPromiseRejectBlock)reject) {
     [ACPIdentity getIdentifiers:^(NSArray<ACPMobileVisitorId *> * _Nullable visitorIDs) {
         NSMutableArray *visitorIDArr = [NSMutableArray array];

--- a/ios/src/Identity/RCTACPIdentity.m
+++ b/ios/src/Identity/RCTACPIdentity.m
@@ -37,9 +37,9 @@ RCT_EXPORT_METHOD(appendVisitorInfoForURL:(nonnull NSString*)baseUrl resolver:(R
     }];
 }
 
-RCT_EXPORT_METHOD(getUrlVariables:((RCTPromiseResolveBlock) resolve rejecter:(RCTPromiseRejectBlock)reject) {
-    [ACPIdentity getUrlVariables:^(NSURL * _Nullable urlVariables) {
-        resolve(urlVariables.absoluteString);
+RCT_EXPORT_METHOD(getUrlVariables:(RCTPromiseResolveBlock) resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    [ACPIdentity getUrlVariables:^(NSString * _Nullable urlVariables) {
+        resolve(urlVariables);
     }];
 }
 

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -47,6 +47,7 @@ jest.mock('NativeModules', () => ({
     syncIdentifiersWithAuthState: jest.fn(),
     syncIdentifier: jest.fn(),
     appendVisitorInfoForURL: jest.fn(() => new Promise(resolve => resolve())),
+    getUrlVariables: jest.fn(() => new Promise(resolve => resolve())),
     getIdentifiers: jest.fn(() => new Promise(resolve => resolve())),
     getExperienceCloudId: jest.fn(() => new Promise(resolve => resolve()))
   },

--- a/js/ACPIdentity.js
+++ b/js/ACPIdentity.js
@@ -113,6 +113,24 @@ module.exports = {
   },
 
   /**
+   * @brief Returns visitor information in URL query string form for consumption in hybrid mobile apps.
+   *
+   * Retrieves the visitor identifiers as a URL query parameter string.
+   * There will be no leading '&' or '?' punctuation, as the caller is responsible for placing the string in the correct
+   * location of their resulting URL. If there is not a valid URL string to return, or if an error occurs, callback will
+   * contain nil. Otherwise, the following information is added to the query section of the given URL.
+   * The attribute `adobe_mc` is an URL encoded list containing the Experience Cloud ID, Experience Cloud Org ID,
+   * Analytics Tracking ID if available from Analytics, and a timestamp when this request
+   * was made. The attribute `adobe_aa_vid` is the URL encoded Analytics Customer Visitor ID, if previously set in
+   * Analytics extension.
+   *
+   * @param promise method which will be invoked once the url query parameter string is available.
+   */
+  getUrlVariables(): Promise<?string> {
+    return RCTACPIdentity.getUrlVariables();
+  },
+
+  /**
    * @brief Returns all customer identifiers which were previously synced with the Adobe Experience Cloud.
    *
    * @param callback method which will be invoked once the customer identifiers are available.

--- a/sample/ACPCoreSample/App.js
+++ b/sample/ACPCoreSample/App.js
@@ -47,6 +47,7 @@ export default class App extends Component<Props> {
         <Button title="ACPIdentity::syncIdentifiersWithAuthState()" onPress={this.syncIdentifiersWithAuthState}/>
         <Button title="ACPIdentity::syncIdentifier()" onPress={this.syncIdentifier}/>
         <Button title="ACPIdentity::appendVisitorInfoForURL()" onPress={this.appendVisitorInfoForURL}/>
+        <Button title="ACPIdentity::getUrlVariables()" onPress={this.getUrlVariables}/>
         <Button title="ACPIdentity::getIdentifiers()" onPress={this.getIdentifiers}/>
         <Button title="ACPIdentity::getExperienceCloudId()" onPress={this.getExperienceCloudId}/>
         </ScrollView>
@@ -160,6 +161,10 @@ export default class App extends Component<Props> {
 
   appendVisitorInfoForURL() {
     ACPIdentity.appendVisitorInfoForURL("test.com").then(urlWithVisitorData => console.log("AdobeExperienceSDK: VisitorData = " + urlWithVisitorData));
+  }
+
+  getUrlVariables() {
+    ACPIdentity.getUrlVariables().then(urlVariables => console.log("AdobeExperienceSDK: UrlVariables = " + urlVariables));
   }
 
   getIdentifiers() {


### PR DESCRIPTION
Add ACPIdentity.getUrlVariables API

## Description

Add ACPIdentity.getUrlVariables() API. Requires react-native-acpcore version 1.0.4 which includes ACPIdentity Android v1.1.0 and iOS v2.1.0.
Adds unit and manual tests for new API.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
