### PR TITLE
add podspec

### DIFF
--- a/RCTACPCore.podspec
+++ b/RCTACPCore.podspec
@@ -1,0 +1,30 @@
+require "json"
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+Pod::Spec.new do |s|
+  s.name         = "RCTACPCore"
+  s.version      = package["version"]
+  s.summary      = "Use Adobe Experience SDKs with React Native"
+  s.author       = "Adobe"
+
+  s.homepage     = "https://github.com/adobe/react-native-acpcore"
+
+  s.license      = "Apache License"
+  s.platform     = :ios
+
+  s.source       = { :git => "https://github.com/adobe/react-native-acpcore.git", :tag => "#{s.version}" }
+
+  s.source_files  = "ios/**/*.{h,m}"
+  s.requires_arc = true
+
+  s.dependency "React"  
+  s.dependency "ACPGriffonBeta", "~> 0.0"
+  s.dependency "ACPTargetVEC", "~> 2.0'"
+  s.dependency "ACPTarget", "~> 2.1'"
+  s.dependency "ACPAudience", "~> 2.0'"
+  s.dependency "ACPAnalytics", "~> 2.0'"
+  s.dependency "ACPUserProfile", "~> 2.0'"
+  s.dependency "ACPCore", "~> 2.0"
+  s.frameworks = 'UIKit', 'SystemConfiguration', 'WebKit', 'UserNotifications'
+  s.library = 'sqlite3.0', 'c++', 'z'
+end

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ public void onCreate() {
 ```
 
 #### 3.2 iOS project
+
+#### With Cocoapods
+* Add `pod 'RCTACPCore', :path => '../node_modules/@adobe/react-native-acpcore'` to your `ios/Podfile`
+* Run `pod install` on `/ios`
+
+#### Manual installation
+* 
 In the Link Binary With Libraries section, click the + link and add the following frameworks and libraries:
 * `UIKit.framework`
 * `SystemConfiguration.framework`


### PR DESCRIPTION
Add podspec file

## Description

Adds podspec file to root, allowing this module to be managed by cocoapods

## Related Issue

https://github.com/adobe/react-native-acpcore/issues/2

## Motivation and Context

React Native projects that have all dependencies managed by cocoapods would break pattern to use this @adobe/react-native-acpcore

## How Has This Been Tested?

1. Add `pod 'RCTACPCore', :path => '../node_modules/@adobe/react-native-acpcore'` to your podfile
2. Run `pod install` in the `ios/` directory
3. Use module as usual on ios

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [  ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
