### PR TITLE
v1.1.1 Always resolve start promise when called multiple times, update libs

### DIFF
--- a/android/src/main/java/com/adobe/marketing/mobile/reactnative/RCTACPCoreModule.java
+++ b/android/src/main/java/com/adobe/marketing/mobile/reactnative/RCTACPCoreModule.java
@@ -23,17 +23,17 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReadableMap;
 
-import android.app.Activity;
 import android.app.Application;
-import android.util.Log;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class RCTACPCoreModule extends ReactContextBaseJavaModule {
 
     private final ReactApplicationContext reactContext;
     private static String FAILED_TO_CONVERT_EVENT_MESSAGE = "Failed to convert map to Event";
+    private static AtomicBoolean hasStarted = new AtomicBoolean(false);
 
     public RCTACPCoreModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -58,10 +58,16 @@ public class RCTACPCoreModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void start(final Promise promise) {
+        if (hasStarted.get()) {
+            promise.resolve(true);
+            return;
+        }
+
         MobileCore.start(new AdobeCallback() {
             @Override
             public void call(Object obj) {
-                promise.resolve(true);
+            hasStarted.set(true);
+            promise.resolve(true);
             }
         });
     }

--- a/ios/src/Core/RCTACPCore.m
+++ b/ios/src/Core/RCTACPCore.m
@@ -54,9 +54,20 @@ RCT_EXPORT_METHOD(extensionVersion: (RCTPromiseResolveBlock) resolve rejecter:(R
 }
 
 RCT_EXPORT_METHOD(start: (RCTPromiseResolveBlock) resolve rejecter:(RCTPromiseRejectBlock)reject) {
-    [ACPCore start:^{
-        resolve(@(YES));
-    }];
+    static BOOL hasStarted = NO;
+    static dispatch_once_t onceToken;
+    
+    if (hasStarted) {
+        resolve(@(hasStarted));
+        return;
+    }
+    
+    dispatch_once(&onceToken, ^{
+        [ACPCore start:^{
+            hasStarted = YES;
+            resolve(@(hasStarted));
+        }];
+    });
 }
 
 RCT_EXPORT_METHOD(configureWithAppId:(NSString* __nullable) appId) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/react-native-acpcore",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/react-native-acpcore",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Adobe Experience Platform support for React Native apps.",
   "homepage": "https://aep-sdks.gitbook.io/docs/",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In the native SDK the callback to `start` is not invoked if `start` is called more than once and the React Native wrapper follows this. This leads to the `Promise` on the JS side to never be fulfilled if `start` is called multiple times.

This is mainly useful when hot reloading your app during development.

<!--- Describe your changes in detail -->

## Related Issue

Fixes https://github.com/adobe/react-native-acpcore/issues/40

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
